### PR TITLE
fix: usage example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,8 +31,10 @@ service.authorization = authorization
 # Build notification message (with topic)
 message = Google::Apis::Messages::Message.new(
   topic: 'news',
-  title: 'Breaking news',
-  body: 'Hell has frozen over'
+  notification: {
+    title: 'Breaking news',
+    body: 'Hell has frozen over'
+  }
 )
 ```
 
@@ -42,8 +44,10 @@ or
 # Build notification message (with token)
 message = Google::Apis::Messages::Message.new(
   token: 'bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1',
-  title: 'Breaking news',
-  body: 'Hell has frozen over'
+  notification: {
+    title: 'Breaking news',
+    body: 'Hell has frozen over'
+  }
 )
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -1,9 +1,12 @@
 # Google API Client for FCM
+
 Extension for original [google-api-client](https://github.com/google/google-api-ruby-client) with implementation of 
 [Firebase Cloud Messaging Server API](https://firebase.google.com/docs/cloud-messaging/server) via HTTP V1 protocol. 
 
 ## Installation
+
 Add this line to your application's Gemfile:
+
 ```ruby
 gem 'google-api-fcm'
 ```
@@ -15,6 +18,7 @@ $ bundle
 ```
 
 ## Usage
+
 ```ruby
 require 'google/apis/messages'
 

--- a/README.MD
+++ b/README.MD
@@ -13,7 +13,7 @@ gem 'google-api-fcm'
 
 And then execute:
 
-```
+```shell
 $ bundle
 ```
 


### PR DESCRIPTION
Hello.
I found the [usage example](https://github.com/oniksfly/google-api-fcm#usage) from the readme is not worked.

So I looked [Message class](https://github.com/oniksfly/google-api-fcm/blob/aaa7db04dd75e422498f9450115b679b60bbc664/lib/google/apis/messages/classes.rb#L18) code and I found `title` and `body` key should be nested by `notification` key, like [FCM docs](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#resource:-message).

This PR correct these usage example, and lint some MD syntax.